### PR TITLE
resolved market price issue

### DIFF
--- a/src/call_market_price2.py
+++ b/src/call_market_price2.py
@@ -168,7 +168,8 @@ class MarketPrice2:
         
         # If there is a bid-ask spread return the midpoint price
         if min_offer_price > max_bid_price:
-            return (max_bid_price + min_offer_price)/2
+            midpoint_price = (max_bid_price + min_offer_price)/2
+            return midpoint_price, 0
 
 
         


### PR DESCRIPTION
Quick fix made to ensure that `MarketPrice2.get_market_price` always returns both market price as well as volume regardless of order book state.